### PR TITLE
Fix TabLayout for new versions of React Native. Allow custom views.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 build/
 npm-debug.log
+
+*.iml

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -17,7 +17,7 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile 'com.facebook.react:react-native:0.15.+'
+    compile 'com.facebook.react:react-native:+'
     compile 'com.android.support:appcompat-v7:23.0.0'
     compile 'com.android.support:support-annotations:+'
     compile 'com.android.support:design:23.1.1'

--- a/android/src/main/java/com/reactnativeandroiddesignsupport/ReactNestedScrollViewHelper.java
+++ b/android/src/main/java/com/reactnativeandroiddesignsupport/ReactNestedScrollViewHelper.java
@@ -14,13 +14,16 @@ package com.reactnativeandroiddesignsupport;
  */
 
 // EDITED: 1. Import additional classes
-import com.facebook.react.views.scroll.ScrollEvent;
-
 import android.os.SystemClock;
 import android.view.View;
 import android.view.ViewGroup;
+
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.uimanager.UIManagerModule;
+import com.facebook.react.views.scroll.ReactHorizontalScrollView;
+import com.facebook.react.views.scroll.ReactScrollView;
+import com.facebook.react.views.scroll.ScrollEvent;
+import com.facebook.react.views.scroll.ScrollEventType;
 
 /**
  * Helper class that deals with emitting Scroll Events.
@@ -37,6 +40,7 @@ public class ReactNestedScrollViewHelper {
         ScrollEvent.obtain(
             scrollView.getId(),
             SystemClock.uptimeMillis(),
+            ScrollEventType.SCROLL,
             scrollX,
             scrollY,
             contentView.getWidth(),

--- a/android/src/main/java/com/reactnativeandroiddesignsupport/ReactNestedScrollViewManager.java
+++ b/android/src/main/java/com/reactnativeandroiddesignsupport/ReactNestedScrollViewManager.java
@@ -15,27 +15,21 @@ package com.reactnativeandroiddesignsupport;
  */
 
 // EDITED: 1. Import additional classes
-import com.facebook.react.views.scroll.OnScrollDispatchHelper;
-import com.facebook.react.views.scroll.ReactHorizontalScrollView;
-import com.facebook.react.views.scroll.ReactHorizontalScrollViewManager;
-import com.facebook.react.views.scroll.ReactScrollView;
-import com.facebook.react.views.scroll.ReactScrollViewCommandHelper;
-import com.facebook.react.views.scroll.ReactScrollViewHelper;
-import com.facebook.react.views.scroll.ReactScrollViewManager;
-import com.facebook.react.views.scroll.ScrollEvent;
 import android.view.ViewGroup;
-import android.support.v4.widget.NestedScrollView;
-import android.support.design.widget.CoordinatorLayout;
-import android.support.design.widget.AppBarLayout;
 
-import javax.annotation.Nullable;
-import java.util.Map;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.uimanager.ReactProp;
 import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
+import com.facebook.react.views.scroll.ReactHorizontalScrollView;
+import com.facebook.react.views.scroll.ReactScrollView;
+import com.facebook.react.views.scroll.ReactScrollViewCommandHelper;
 import com.facebook.react.views.view.ReactClippingViewGroupHelper;
+
+import java.util.Map;
+
+import javax.annotation.Nullable;
 /**
  * View manager for {@link ReactScrollView} components.
  *
@@ -88,7 +82,7 @@ public class ReactNestedScrollViewManager
       ReactScrollViewCommandHelper.ScrollToCommandData data) {
     scrollView.smoothScrollTo(data.mDestX, data.mDestY);
   }
-  @Override
+
   public void scrollWithoutAnimationTo(
       ReactNestedScrollView scrollView,
       ReactScrollViewCommandHelper.ScrollToCommandData data) {
@@ -97,7 +91,7 @@ public class ReactNestedScrollViewManager
   @Override
   public @Nullable Map getExportedCustomDirectEventTypeConstants() {
     return MapBuilder.builder()
-        .put(ScrollEvent.EVENT_NAME, MapBuilder.of("registrationName", "onScroll"))
+        .put("topScroll", MapBuilder.of("registrationName", "onScroll"))
         .put("topScrollBeginDrag", MapBuilder.of("registrationName", "onScrollBeginDrag"))
         .put("topScrollEndDrag", MapBuilder.of("registrationName", "onScrollEndDrag"))
         .put("topScrollAnimationEnd", MapBuilder.of("registrationName", "onScrollAnimationEnd"))


### PR DESCRIPTION
- Updated to use most recent version of React Native
- Later versions of React Native moved `ReactProp` to the `uimanager/annotations` directory. That is why the properties like `selectedColor` were not getting updated.
- Made some changes so that custom tab views will work.
- Fixed some other small breaking changes due to using newer version of React Native
- Made some changes so that the `NativeViewHierarchyManager.dropView()` does not throw during cleanup.
